### PR TITLE
Updated Maven dependencies

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>1.10.0</version>
+			<version>1.10.19</version>
 			<scope>test</scope>
 	  	</dependency>
         <dependency>


### PR DESCRIPTION
Mockito-Core 1.10.0 isn't available via Maven anymore (http://mvnrepository.com/artifact/org.mockito/mockito-core). This causes the build to fail.
